### PR TITLE
add scale and border radius

### DIFF
--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -59,14 +59,27 @@ const textImageRequestParser = (
 const featuredImageRequestParser = (
   encodedQuery: string
 ): FeaturedImageRequest => {
-  const { imageURL, bg } = JSON.parse(
+  const { imageURL, bg, scale, borderRadius } = JSON.parse(
     Buffer.from(encodedQuery, "base64").toString("binary")
   );
+
+  // Because we are taking a larger screenshot,
+  // Need to increase scale that we receive to better match user's values
+  // e.g. if user requests scale=0.5, we need to scale up to 0.75
+  let newScale = scale;
+
+  if (scale) {
+    if (!isNaN(parseFloat(scale))) {
+      newScale = parseFloat(scale) + 0.6 + "";
+    }
+  }
 
   const parsedRequest: FeaturedImageRequest = {
     fileType: "png",
     imageURL,
     bg,
+    scale: newScale,
+    borderRadius,
   };
 
   return parsedRequest;

--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -35,9 +35,17 @@ interface CssOptions {
   textInfo?: TextInfo;
   brandingInfo?: BrandingInfo;
   gradient?: string;
+  scale?: string;
+  borderRadius?: string;
 }
 
-function getCss({ textInfo, brandingInfo, gradient }: CssOptions) {
+function getCss({
+  textInfo,
+  brandingInfo,
+  gradient,
+  borderRadius,
+  scale,
+}: CssOptions) {
   const background = brandingInfo?.bg ?? "";
   const foreground = brandingInfo?.color ?? "";
 
@@ -174,10 +182,22 @@ function getCss({ textInfo, brandingInfo, gradient }: CssOptions) {
       padding: 48px 96px;
     }
 
-    .featured-image {
-      object-fit: contain;
+    .featured-image-scale {
       width: 100%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      transform: scale(${scale});
+
+    }
+
+    .featured-image {
+      width: auto;
       height: auto;
+      min-width: auto;
+      min-height: auto;
+      margin: auto;
+      border-radius: ${borderRadius};
     }
     `;
 }
@@ -217,8 +237,10 @@ export function getHtml(parsedReq: ParsedRequest) {
   if (featuredImageReq) {
     featuredImageReqHTML = `
       <div class="featured-image-wrapper">
-      
-      <img src=${featuredImageReq.imageURL} class="featured-image"/>
+        <div class="featured-image-scale">
+
+          <img src=${featuredImageReq.imageURL} class="featured-image"/>
+        </div>
       </div>
   `;
   }
@@ -234,6 +256,8 @@ export function getHtml(parsedReq: ParsedRequest) {
               textInfo: textImageReq?.textInfo,
               brandingInfo: textImageReq?.brandingInfo,
               gradient: featuredImageReq?.bg,
+              scale: featuredImageReq?.scale,
+              borderRadius: featuredImageReq?.borderRadius,
             })}
         </style>
         <body>

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -22,6 +22,8 @@ export type FeaturedImageRequest = {
   fileType: FileType;
   imageURL: string;
   bg?: string;
+  scale?: string;
+  borderRadius?: string;
 };
 
 export type ParsedRequest = TextImageRequest | FeaturedImageRequest;


### PR DESCRIPTION
This PR adds `scale` and `borderRadius`. 

Also attempts to match the `scale` that the user selected. 
The screenshot that is taken for the open-graph image is larger than how the images are displayed in the app, so needed to add to the scale value.