### PR TITLE
Scale border radius

### DIFF
--- a/api/_lib/chromium.ts
+++ b/api/_lib/chromium.ts
@@ -1,22 +1,51 @@
-import core from 'puppeteer-core';
-import { getOptions } from './options';
-import { FileType } from './types';
+import core from "puppeteer-core";
+import { getOptions } from "./options";
+import { FileType } from "./types";
 let _page: core.Page | null;
 
 async function getPage(isDev: boolean) {
-    if (_page) {
-        return _page;
-    }
-    const options = await getOptions(isDev);
-    const browser = await core.launch(options);
-    _page = await browser.newPage();
+  if (_page) {
     return _page;
+  }
+  const options = await getOptions(isDev);
+  const browser = await core.launch(options);
+  _page = await browser.newPage();
+  return _page;
 }
 
-export async function getScreenshot(html: string, type: FileType, isDev: boolean) {
-    const page = await getPage(isDev);
-    await page.setViewport({ width: 2048, height: 1170 });
-    await page.setContent(html);
-    const file = await page.screenshot({ type });
-    return file;
+export async function getScreenshot(
+  html: string,
+  type: FileType,
+  isDev: boolean
+) {
+  const page = await getPage(isDev);
+
+  await page.setViewport({ width: 2048, height: 1170 });
+  await page.setContent(html);
+
+  const scaledImage = await page.$(".featured-image");
+
+  if (scaledImage) {
+    const imageTooBig = await scaledImage.evaluate((el) => {
+      const divEl = el as HTMLDivElement;
+
+      const imageWidth = divEl.getBoundingClientRect().width;
+      const imageHeight = divEl.getBoundingClientRect().height;
+
+      if (imageWidth > 2048 || imageHeight > 1170) {
+        return true;
+      }
+      return false;
+    });
+
+    const imageScaler = await page.$(".featured-image-scale");
+    if (imageScaler && imageTooBig) {
+      await imageScaler.evaluate((el) => {
+        const divEl = el as HTMLDivElement;
+        divEl.style.transform = "scale(1)";
+      });
+    }
+  }
+  const file = await page.screenshot({ type });
+  return file;
 }

--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -70,7 +70,7 @@ const featuredImageRequestParser = (
 
   if (scale) {
     if (!isNaN(parseFloat(scale))) {
-      newScale = parseFloat(scale) + 0.6 + "";
+      newScale = parseFloat(scale) + 1.0 + "";
     }
   }
 

--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -180,6 +180,7 @@ function getCss({
       display: flex;
       justify-content: center;
       padding: 48px 96px;
+      overflow: hidden;
     }
 
     .featured-image-scale {
@@ -187,15 +188,14 @@ function getCss({
       height: 100%;
       display: flex;
       justify-content: center;
+      overflow: hidden;
       transform: scale(${scale});
 
     }
 
     .featured-image {
-      width: auto;
-      height: auto;
-      min-width: auto;
-      min-height: auto;
+      max-width: 100%;
+      max-height: 100%;
       margin: auto;
       border-radius: ${borderRadius};
     }
@@ -265,7 +265,7 @@ export function getHtml(parsedReq: ParsedRequest) {
             ${textImageReqHTML}
 
             ${featuredImageReqHTML}
-        </body>
+        </body>     
     </html>`;
 }
 


### PR DESCRIPTION
The previous pr introduced `scale` and `border radius`. However, these values needed to be tweaked after testing.

This Pr does the following:
 - Increases the `scale`by 1.0 to help smaller images look larger in the preview
 - Adds puppeteer handling if the image is larger than the screenshot size 